### PR TITLE
Fix buf_read() heap corruption on large files and read() errors

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -35,3 +35,5 @@ dparser.*\.(zip|pdf)$
 ^docs$
 ^pkgdown$
 ^revdep$
+^tests/audit-reproducers$
+^tests/audit-reproducers/.*$

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # dparser 1.3.2
 
+- `buf_read()` (and therefore `sbuf_read()`) is hardened in three
+  ways without changing its `int *len` ABI:
+    * Files larger than `INT_MAX - 2` bytes are now rejected with `-1`
+      instead of silently truncating `off_t -> int` and producing a
+      negative `*len` that the rest of the function then misused as a
+      buffer size.  Verified: a 3 GiB sparse file used to SIGSEGV in
+      `buf_read` at `(*buf)[real_size] = 0`; after the fix it returns
+      `-1` cleanly.
+    * `read()`'s `ssize_t` return is now stored in `ssize_t`, not
+      `size_t`.  On a `read()` error (returning `-1`), the previous
+      code would index `(*buf)[SIZE_MAX]` — heap corruption.  The new
+      code frees the buffer and returns `-1`.
+    * `if (fd <= 0)` -> `if (fd < 0)` so that fd `0` is treated as a
+      valid descriptor (it is the stdin slot, returned by `open()` if
+      stdin has been closed).
+
 - Add `udparse(D_Parser*, char *buf, unsigned int buf_len)` as a
   memory-safe alternative to `dparse(D_Parser*, char *buf, int buf_len)`.
   Existing callers of `dparse` still compile and link unchanged; the

--- a/src/util.c
+++ b/src/util.c
@@ -46,21 +46,35 @@ uint strhashl(const char *s, int l) {
 int buf_read(const char *pathname, char **buf, int *len) {
   struct stat sb;
   int fd;
-  size_t real_size;
+  ssize_t real_size;
+  off_t fsize;
 
   *buf = 0;
   *len = 0;
   fd = open(pathname, O_RDONLY);
-  if (fd <= 0) return -1;
+  if (fd < 0) return -1;
   memset(&sb, 0, sizeof(sb));
-  fstat(fd, &sb);
-  *len = sb.st_size;
-  *buf = (char *)MALLOC(*len + 2);
+  if (fstat(fd, &sb) != 0) { close(fd); return -1; }
+  fsize = sb.st_size;
+  if (fsize < 0 || (uintmax_t)fsize > (uintmax_t)(INT_MAX - 2)) {
+    close(fd);
+    return -1;
+  }
+  *len = (int)fsize;
+  *buf = (char *)MALLOC((size_t)*len + 2);
+  if (!*buf) { close(fd); return -1; }
   /* MINGW likes to convert cr lf => lf which messes with the size */
-  real_size = read(fd, *buf, *len);
+  real_size = read(fd, *buf, (size_t)*len);
+  if (real_size < 0) {
+    FREE(*buf);
+    *buf = NULL;
+    *len = 0;
+    close(fd);
+    return -1;
+  }
   (*buf)[real_size] = 0;
   (*buf)[real_size + 1] = 0;
-  *len = real_size;
+  *len = (int)real_size;
   close(fd);
   return *len;
 }

--- a/tests/audit-reproducers/buf-read-large-files.c
+++ b/tests/audit-reproducers/buf-read-large-files.c
@@ -1,0 +1,77 @@
+/*
+ * Reproducer for src/util.c:buf_read() bugs (Branch 3):
+ *
+ *   3a. `*len = sb.st_size` narrowed off_t (typically 64-bit) to int.
+ *       Files in (INT_MAX, UINT_MAX] silently produced negative *len, then
+ *       `MALLOC(*len + 2)` was a near-SIZE_MAX request (often refused on
+ *       Linux without overcommit) and `read(fd, *buf, *len)` had undefined
+ *       behaviour for negative size.
+ *
+ *   3b. `size_t real_size = read(fd, *buf, *len)` stored read()'s ssize_t
+ *       return into a size_t.  On read() failure, -1 became SIZE_MAX, then
+ *       `(*buf)[real_size] = 0` wrote at offset SIZE_MAX — heap corruption
+ *       or SIGSEGV.
+ *
+ *   Cosmetic: `if (fd <= 0) return -1` should be `if (fd < 0)`.
+ *       fd 0 is a legitimate descriptor (stdin slot, returned by open()
+ *       when stdin has been closed).  Unlikely to bite anyone, but wrong.
+ *
+ * BEFORE FIX: 3GB sparse file -> negative *len -> bogus state.
+ * AFTER FIX: buf_read returns -1 cleanly; *buf = NULL; *len = 0.
+ *
+ * Build (run from package root, after src/dparser.so has been built):
+ *   gcc -g -O0 -o tests/audit-reproducers/buf-read-large-repro \
+ *       tests/audit-reproducers/buf-read-large-files.c \
+ *       -ldl -Wl,-rpath,/usr/lib/R/lib -L/usr/lib/R/lib -lR
+ *
+ * Run:
+ *   ./tests/audit-reproducers/buf-read-large-repro
+ *
+ * Expected output AFTER fix:
+ *   Created 3 GiB sparse file at /tmp/dparser-audit-buf-read-XXXXXX
+ *   buf_read returned -1 (correctly rejected)  *len = 0  *buf = (nil)
+ *
+ * BEFORE the fix, *len would be sb.st_size cast to int (a small or
+ * negative value depending on how the truncation lands), and the
+ * subsequent allocation/read/index sequence would either crash or silently
+ * succeed with garbage.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <dlfcn.h>
+
+int main(void) {
+  void *h = dlopen("./src/dparser.so", RTLD_LAZY);
+  if (!h) { fprintf(stderr, "dlopen: %s\n", dlerror()); return 2; }
+  int (*buf_read_fn)(const char *, char **, int *) = dlsym(h, "buf_read");
+  if (!buf_read_fn) { fprintf(stderr, "dlsym: %s\n", dlerror()); return 2; }
+
+  char path[] = "/tmp/dparser-audit-buf-read-XXXXXX";
+  int fd = mkstemp(path);
+  if (fd < 0) { perror("mkstemp"); return 2; }
+  /* Sparse 3 GiB file via ftruncate — no actual disk space used. */
+  off_t target = (off_t)3 * 1024 * 1024 * 1024;
+  if (ftruncate(fd, target) != 0) { perror("ftruncate"); close(fd); unlink(path); return 2; }
+  close(fd);
+  fprintf(stderr, "Created %.1f GiB sparse file at %s\n",
+          (double)target / (1024.0 * 1024.0 * 1024.0), path);
+
+  char *buf = (char *)0xDEADBEEF;
+  int len = 0xDEAD;
+  int rc = buf_read_fn(path, &buf, &len);
+  fprintf(stderr,
+          "buf_read returned %d %s  *len = %d  *buf = %p\n",
+          rc,
+          (rc < 0 ? "(correctly rejected)" : "(WRONG: should have rejected)"),
+          len, (void *)buf);
+
+  unlink(path);
+  if (buf && rc >= 0) free(buf);
+  dlclose(h);
+  return rc < 0 ? 0 : 1;
+}

--- a/tests/testthat/test-mem-buf-read-large.R
+++ b/tests/testthat/test-mem-buf-read-large.R
@@ -1,0 +1,29 @@
+test_that("buf_read rejects oversized files cleanly and survives read() errors", {
+  # The audit identified three bugs in src/util.c:buf_read():
+  #
+  #   3a. `*len = sb.st_size` narrowed off_t (typically 64-bit) to int.
+  #       For files in (INT_MAX, UINT_MAX] (~2-4 GiB), *len became
+  #       negative and the subsequent MALLOC(*len + 2) was either a
+  #       huge-size request (typically NULL) or behaved unpredictably.
+  #
+  #   3b. `size_t real_size = read(fd, *buf, *len);` assigned read()'s
+  #       ssize_t return into a size_t.  read()'s -1 became SIZE_MAX,
+  #       and `(*buf)[real_size] = 0` then wrote at offset SIZE_MAX —
+  #       heap corruption / SIGSEGV.
+  #
+  #   Cosmetic: `if (fd <= 0)` should be `if (fd < 0)` (fd 0 is valid).
+  #
+  # Verification of 3a uses a 3 GiB sparse file (no actual disk space).
+  # See tests/audit-reproducers/buf-read-large-files.c — the C
+  # reproducer dlopens dparser.so and calls buf_read directly to
+  # bypass the rdparse.c strlen(NULL) bug (which is fixed in a separate
+  # branch, fix/rdparse-strlen-on-null-and-int-trunc).
+  #
+  # gdb-confirmed crash on the unfixed build:
+  #   #0  buf_read (... pathname="/tmp/.../big.bin") at util.c:61
+  #         (*buf)[real_size] = 0;       /* real_size == (size_t)-1 */
+  # After the fix, the same reproducer prints:
+  #   buf_read returned -1 (correctly rejected)  *len = 0  *buf = (nil)
+  skip("manual reproducer; see tests/audit-reproducers/buf-read-large-files.c")
+  expect_true(TRUE)
+})


### PR DESCRIPTION
Three related bugs in src/util.c:buf_read():

1. *len = sb.st_size silently narrowed off_t -> int. Files in
   (INT_MAX, UINT_MAX] produced negative *len; subsequent
   MALLOC/read had undefined behavior.

2. size_t real_size = read(...) stored read()'s -1 as SIZE_MAX,
   then (*buf)[real_size] = 0 wrote at offset SIZE_MAX -- heap
   corruption.

3. Cosmetic: if (fd <= 0) should be if (fd < 0). fd 0 is valid.

gdb on a 3 GiB sparse file (no actual disk space):
  #0  buf_read (...) at util.c:61   (*buf)[real_size] = 0;

Fix: ssize_t for read(), reject oversize files explicitly with -1,
fix fd check. Preserves int *len ABI.

Reproducer: tests/audit-reproducers/buf-read-large-files.c.